### PR TITLE
Add python version 3.12

### DIFF
--- a/gcp-function-https/variabes.tf
+++ b/gcp-function-https/variabes.tf
@@ -25,6 +25,7 @@ variable "runtime" {
       "nodejs14",
       "nodejs12",
       "nodejs10",
+      "python312",
       "python311",
       "python310",
       "python39",

--- a/gcp-function-pubsub/variabes.tf
+++ b/gcp-function-pubsub/variabes.tf
@@ -25,6 +25,7 @@ variable "runtime" {
       "nodejs14",
       "nodejs12",
       "nodejs10",
+      "python312",
       "python311",
       "python310",
       "python39",

--- a/gcp-function-schedule/variabes.tf
+++ b/gcp-function-schedule/variabes.tf
@@ -25,6 +25,7 @@ variable "runtime" {
       "nodejs14",
       "nodejs12",
       "nodejs10",
+      "python312",
       "python311",
       "python310",
       "python39",


### PR DESCRIPTION
GCP Functions already support Python 3.12.
Source: https://cloud.google.com/functions/docs/concepts/execution-environment
Happy coding,
Nik